### PR TITLE
fix: register version as an output of the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   prerelease:
     description: 'Pre-release version alpha|beta|...'
     required: false
+outputs:
+  version:
+    description: 'New version number`
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Adds an outputs entry to register the `version` output that is set.

This should fix #52